### PR TITLE
fix: correct errored flag used before process.exit

### DIFF
--- a/packages/reflow-core/lib/execute.js
+++ b/packages/reflow-core/lib/execute.js
@@ -3,6 +3,10 @@ const Duration = require('duration');
 const threadPool = require('./thread-pool')
 const {analyzeCombination} = require('./analyze')
 
+let failures = 0;
+let errored = false;
+let done = false;
+
 const executeMatrix = function(matrix, config) {
   const {
     mocha: mochaConfig,
@@ -32,11 +36,7 @@ const executeMatrix = function(matrix, config) {
     customActions,
   });
 
-
   matrix.forEach(sendToPool);
-  let failures = 0;
-  let errored = false;
-  let done = false;
 
   pool
     .on('done', function(job, jobFailures) {
@@ -58,8 +58,10 @@ const executeMatrix = function(matrix, config) {
 
   process.on('exit', function() {
     if(!done) console.log('Exited before done')
+
     process.exit(+!!(errored || failures));
   })
+
   return pool
 }
 


### PR DESCRIPTION
The flag used to exist per child Node process, causing the
main process to never have it updated, thus any non-assertion
error would not be detected by the exit status code of Reflow.

Moving the control variables to the top level scope seems to have fixed the issue